### PR TITLE
Fix typo in USWDS link

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -420,7 +420,7 @@ Budget requests for custom software often feature non-technical people making a 
 #### Checklist
 
 - □ The agency will rely on the U.S. Digital Service's [Digital Services Playbook](https://playbook.cio.gov/)
-- □ If building a website, the agency will direct the vendor to use the [S. Web Design System](https://designsystem.digital.gov/)
+- □ If building a website, the agency will direct the vendor to use the [U.S. Web Design System](https://designsystem.digital.gov/)
 - □ The agency will adhere to the Defense Innovation Board's "[Ten Commandments of Software](https://media.defense.gov/2018/Apr/22/2001906836/-1/-1/0/DEFENSEINNOVATIONBOARD_TEN_COMMANDMENTS_OF_SOFTWARE_2018.04.20.PDF)"
 - □ The agency has read this playbook
 - □ The rules and questions found in the Defense Innovation Board's "[Detecting Agile BS](https://media.defense.gov/2018/Oct/09/2002049591/-1/-1/0/DIB_DETECTING_AGILE_BS_2018.10.05.PDF)" guide have been applied to and asked of the agency, and their answers are satisfactory


### PR DESCRIPTION
Changed "S. Web Design System" to "U.S. Web Design System".