### PR TITLE
Fix typo

### DIFF
--- a/handbook.md
+++ b/handbook.md
@@ -416,7 +416,7 @@ If the software is published openly, vendors’ employees will be eager to work 
 #### Checklist
 
 - [ ] The RFP will require that software source code be written and maintained in public on a social-coding platform (e.g., [GitHub](http://github.com/) or [GitLab](https://gitlab.com/)), from day one
-- [ ] The RFP will require that software be explicitly dedicated to the public domain or published under an [pen source license](https://opensource.org/licenses)
+- [ ] The RFP will require that software be explicitly dedicated to the public domain or published under an [open source license](https://opensource.org/licenses)
 - [ ] The RFP will use best security practices by requiring that software be strictly separated from data and secrets (e.g., passwords), with automated testing to make sure that separation is maintained
 - [ ] The RFP will require that software be documented sufficiently well that a developer with no connection to the project can use it to run their own copy of the software
 


### PR DESCRIPTION
'open source' missing the 'o'